### PR TITLE
Created editor fix for Unity editors prior to 5.6 

### DIFF
--- a/Assets/MultiBuild/Editor/SettingsWindow.cs
+++ b/Assets/MultiBuild/Editor/SettingsWindow.cs
@@ -343,9 +343,12 @@ namespace MultiBuild {
             // Building can change the active target, can cause warnings or odd behaviour
             // Put it back to how it was
             if (EditorUserBuildSettings.activeBuildTarget != savedTarget) {
+#if UNITY_5_6
                 EditorUserBuildSettings.SwitchActiveBuildTarget(GroupForTarget(savedTarget), savedTarget);
+#else
+                EditorUserBuildSettings.SwitchActiveBuildTarget(savedTarget);
+#endif     
             }
-
         }
 
         BuildTargetGroup GroupForTarget(BuildTarget t) {


### PR DESCRIPTION
Created editor fix for Unity 5.5 which uses the method EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTarget) that is obsolete in Unity 5.6.