### PR TITLE
Add full support for Unity versions before 5.6

### DIFF
--- a/Assets/MultiBuild/Editor/Settings.cs
+++ b/Assets/MultiBuild/Editor/Settings.cs
@@ -24,9 +24,7 @@ namespace MultiBuild {
         SamsungTV = 14,
         WiiU = 15,
         tvOS = 16,
-#if UNITY_5_5_OR_NEWER
         Nintendo3DS = 17,
-#endif
 #if UNITY_5_6_OR_NEWER
         Switch = 18,
 #endif

--- a/Assets/MultiBuild/Editor/Settings.cs
+++ b/Assets/MultiBuild/Editor/Settings.cs
@@ -22,13 +22,18 @@ namespace MultiBuild {
         PS4 = 12,
         XboxOne = 13,
         SamsungTV = 14,
-        Nintendo3DS = 15,
-        WiiU = 16,
-        tvOS = 17,
-#if UNITY_5_6
-        Switch = 18
+        WiiU = 15,
+        tvOS = 16,
+#if UNITY_5_5_OR_NEWER
+        Nintendo3DS = 17,
 #endif
+#if UNITY_5_6_OR_NEWER
+        Switch = 18,
+#endif
+
+        Max
     }
+
     public class Settings : ScriptableObject {
 
         public string outputFolder;

--- a/Assets/MultiBuild/Editor/Settings.cs
+++ b/Assets/MultiBuild/Editor/Settings.cs
@@ -22,13 +22,12 @@ namespace MultiBuild {
         PS4 = 12,
         XboxOne = 13,
         SamsungTV = 14,
-        WiiU = 15,
-        tvOS = 16,
-        Nintendo3DS = 17,
+        Nintendo3DS = 15,
+        WiiU = 16,
+        tvOS = 17,
 #if UNITY_5_6_OR_NEWER
         Switch = 18,
 #endif
-
         Max
     }
 

--- a/Assets/MultiBuild/Editor/SettingsWindow.cs
+++ b/Assets/MultiBuild/Editor/SettingsWindow.cs
@@ -68,9 +68,7 @@ namespace MultiBuild {
                         {Target.SamsungTV, "Samsung TV"},
                         {Target.WiiU, "Nintendo WiiU"},
                         {Target.tvOS, "tvOS"},
-#if UNITY_5_5_OR_NEWER
                         {Target.Nintendo3DS, "Nintendo 3DS"},
-#endif
 #if UNITY_5_6_OR_NEWER
                         {Target.Switch, "Nintendo Switch"},
 #endif
@@ -413,6 +411,9 @@ namespace MultiBuild {
 #if UNITY_5_5_OR_NEWER
             case BuildTarget.N3DS:
                 return BuildTargetGroup.N3DS;
+#else
+            case BuildTarget.Nintendo3DS:
+                return BuildTargetGroup.Nintendo3DS;
 #endif
 #if UNITY_5_6_OR_NEWER
             case BuildTarget.Switch:
@@ -463,6 +464,9 @@ namespace MultiBuild {
 #if UNITY_5_5_OR_NEWER
             case Target.Nintendo3DS:
                 return BuildTarget.N3DS;
+#else
+            case Target.Nintendo3DS:
+                return BuildTarget.Nintendo3DS;
 #endif
 #if UNITY_5_6_OR_NEWER
             case Target.Switch:
@@ -509,7 +513,6 @@ namespace MultiBuild {
 
             return o;
         }
-
     }
 
 }


### PR DESCRIPTION
- All UNITY_5_6 conditional guards have been replaced with
UNITY_5_6_OR_NEWER for forwards compatability.
- Nintendo3D build target is activated with Unity 5.5 and upwards
- Deprecated BuildPlayer.BuildPipeline API used on Unity 5.4 and lower

Only tested on Unity 5.4. I'm certain it'll work on 5.5. No guarantee for lower versions.